### PR TITLE
Added minVersion property

### DIFF
--- a/src/main/resources/mixins.epp.json
+++ b/src/main/resources/mixins.epp.json
@@ -1,5 +1,6 @@
 {
   "required": false,
+  "minVersion": "0.8",
   "package": "com.github.glodblock.epp.mixins",
   "refmap": "mixins.epp.refmap.json",
   "compatibilityLevel": "JAVA_17",


### PR DESCRIPTION
To fix `[main/ERROR] [mixin/]: Mixin config mixins.epp.json does not specify "minVersion" property`  this should probably be added to all your mixins across fabric and forge, as far as I know this error is independent of your mod loader.