### PR TITLE
use correct keybinding for the wireless extended pattern access terminal

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/xmod/wt/CommonLoad.java
+++ b/src/main/java/com/glodblock/github/extendedae/xmod/wt/CommonLoad.java
@@ -22,7 +22,7 @@ public class CommonLoad {
                 HostUWirelessExPAT::new,
                 ContainerUWirelessExPAT.TYPE,
                 (IUniversalWirelessTerminalItem) EPPItemAndBlock.WIRELESS_EX_PAT,
-                "wireless_terminal",
+                "wireless_pattern_access_terminal",
                 "item.expatternprovider.wireless_ex_pat"
         );
         Upgrades.add(AE2wtlib.QUANTUM_BRIDGE_CARD, EPPItemAndBlock.WIRELESS_EX_PAT, 1, GuiText.WirelessTerminals.getTranslationKey());


### PR DESCRIPTION
using `wireless_terminal` breaks the keybind for the wireless crafting terminal, and ae2wtlib already has a keybind for the normal pattern access terminal, and imo it makes sense to reuse that.

fixes https://github.com/Mari023/AE2WirelessTerminalLibrary/issues/253