### PR TITLE
Fix title of crystal_fixer.md

### DIFF
--- a/src/main/resources/assets/expatternprovider/ae2guide/epp_intro/crystal_fixer.md
+++ b/src/main/resources/assets/expatternprovider/ae2guide/epp_intro/crystal_fixer.md
@@ -1,7 +1,7 @@
 ---
 navigation:
     parent: epp_intro/epp_intro-index.md
-    title: ME Crystal Growth Chamber
+    title: ME Crystal Fixer
     icon: expatternprovider:crystal_fixer
 categories:
 - extended devices


### PR DESCRIPTION
In the index of the guidebook a different title was used, now it matches the page title.