### PR TITLE
Allow multiple modids to be used in the input of Mod Storage Bus

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/common/me/modlist/ModPriorityList.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/me/modlist/ModPriorityList.java
@@ -4,24 +4,24 @@ import appeng.api.stacks.AEKey;
 import appeng.util.Platform;
 import appeng.util.prioritylist.IPartitionList;
 
-import java.util.List;
+import java.util.*;
 
 public class ModPriorityList implements IPartitionList {
 
-    private final String modid;
+    private final Set<String> modids = new HashSet<>();
 
     public ModPriorityList(String modid) {
-        this.modid = modid;
+        Collections.addAll(this.modids, modid.split(","));
     }
 
     @Override
     public boolean isListed(AEKey input) {
-        return this.modid.equals(input.getModId()) || this.modid.equals(Platform.getModName(input.getModId()));
+        return this.modids.contains(input.getModId()) || this.modids.contains(Platform.getModName(input.getModId()));
     }
 
     @Override
     public boolean isEmpty() {
-        return this.modid.isBlank();
+        return this.modids.isEmpty();
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
+++ b/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
@@ -16,8 +16,9 @@ public class FCClientUtil {
     }
 
     public static String getModName(String inputText) {
-        if (inputText.isEmpty()) return "";
+        if (inputText.isEmpty() || inputText.endsWith(",")) return "";
         for (String mod : LoadList.MOD_NAME) {
+            if(inputText.contains(mod)) continue;
             if (mod.startsWith(inputText)) {
                 int pos = mod.indexOf(inputText);
                 return mod.substring(pos + inputText.length());

--- a/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
+++ b/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
@@ -19,9 +19,11 @@ public class FCClientUtil {
         if (inputText.isEmpty() || inputText.endsWith(",")) return "";
         for (String mod : LoadList.MOD_NAME) {
             if(inputText.contains(mod)) continue;
-            if (mod.startsWith(inputText)) {
-                int pos = mod.indexOf(inputText);
-                return mod.substring(pos + inputText.length());
+            String[] modids = inputText.split(",");
+            String modid = modids[modids.length - 1];
+            if (mod.startsWith(modid)) {
+                int pos = mod.indexOf(modid);
+                return mod.substring(pos + modid.length());
             }
         }
         return "";


### PR DESCRIPTION
This is (finally) the pull request as discussed in #176.

This PR allows the user to input multiple mod ids by seperating them with a comma.
It also updates the suggestions by skipping a suggestion if the modid is already added.

I made this in 1.20.1, but this should be able to get ported to each version without changes, as there are minimal changes to begin with (6 lines in 2 files).

If there are any questions, gladly ask them!
