### PR TITLE
Adjust ExInscriber's stacking mode to align with AE2's behavior. 调整扩展压印器的堆叠模式，使其与 AE2 的行为一致。

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/client/gui/GuiExInscriber.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/GuiExInscriber.java
@@ -46,8 +46,9 @@ public class GuiExInscriber extends UpgradeableScreen<ContainerExInscriber> {
         this.next.setMessage(Component.translatable("gui.extendedae.ex_inscriber.next"));
         this.pre.setMessage(Component.translatable("gui.extendedae.ex_inscriber.pre"));
         CycleEPPButton stackChange = new CycleEPPButton();
-        stackChange.addActionPair(EPPIcon.STACK_1, Component.translatable("gui.extendedae.ex_inscriber.unstackable"), b -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("stack", 64)));
         stackChange.addActionPair(Icon.INSCRIBER_BUFFER_64.getBlitter(), Component.translatable("gui.extendedae.ex_inscriber.stackable"), b -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("stack", 1)));
+        stackChange.addActionPair(Icon.INSCRIBER_BUFFER_1.getBlitter(), Component.translatable("gui.extendedae.ex_inscriber.unstackable"), b -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("stack", 4)));
+        stackChange.addActionPair(Icon.INSCRIBER_BUFFER_4.getBlitter(), Component.translatable("gui.extendedae.ex_inscriber.fourstackable"), b -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("stack", 64)));
         stackChange.setState(this.menu.getStackMode());
         addToLeftToolbar(stackChange);
         addToLeftToolbar(this.next);

--- a/src/main/java/com/glodblock/github/extendedae/common/me/InscriberThread.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/me/InscriberThread.java
@@ -49,11 +49,12 @@ public class InscriberThread {
     private InscriberRecipe cachedTask = null;
 
     public InscriberThread(@NotNull TileExInscriber host) {
+        int DEFAULT_STACK_SIZE = TileExInscriber.DEFAULT_STACK_SIZE;
         this.host = host;
         IAEItemFilter baseFilter = new BaseFilter();
-        this.topItemHandler = new AppEngInternalInventory(this.host, 1, 1, baseFilter);
-        this.bottomItemHandler = new AppEngInternalInventory(this.host, 1, 1, baseFilter);
-        this.sideItemHandler = new AppEngInternalInventory(this.host, 2, 1, baseFilter);
+        this.topItemHandler = new AppEngInternalInventory(this.host, 1, DEFAULT_STACK_SIZE, baseFilter);
+        this.bottomItemHandler = new AppEngInternalInventory(this.host, 1, DEFAULT_STACK_SIZE, baseFilter);
+        this.sideItemHandler = new AppEngInternalInventory(this.host, 2, DEFAULT_STACK_SIZE, baseFilter);
         this.inv = new CombinedInternalInventory(this.topItemHandler, this.bottomItemHandler, this.sideItemHandler);
         this.lastStacks = new IdentityHashMap<>(Map.of(
                 topItemHandler, ItemStack.EMPTY, bottomItemHandler, ItemStack.EMPTY,

--- a/src/main/java/com/glodblock/github/extendedae/common/tileentities/TileExInscriber.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/tileentities/TileExInscriber.java
@@ -57,7 +57,8 @@ public class TileExInscriber extends AENetworkedPoweredBlockEntity implements IG
     private final InternalInventory sideItemHandlerAll;
     private final InternalInventory combinedItemHandlerExternAll;
     private final InternalInventory invAll;
-    private int stackSize = 1;
+    public static final int DEFAULT_STACK_SIZE = 64; //Available value: 1,4,64
+    private int stackSize = DEFAULT_STACK_SIZE;
     private int animationIndex = -1;
 
     public TileExInscriber(BlockPos pos, BlockState blockState) {
@@ -190,7 +191,7 @@ public class TileExInscriber extends AENetworkedPoweredBlockEntity implements IG
         super.loadTag(data, registries);
         this.upgrades.readFromNBT(data, "upgrades", registries);
         this.configManager.readFromNBT(data, registries);
-        this.stackSize = data.contains("stacksize") ? data.getInt("stacksize") : 1;
+        this.stackSize = data.contains("stacksize") ? data.getInt("stacksize") : DEFAULT_STACK_SIZE;
         for (var t : this.threads) {
             t.init();
             t.setStackSize(this.stackSize);

--- a/src/main/java/com/glodblock/github/extendedae/container/ContainerExInscriber.java
+++ b/src/main/java/com/glodblock/github/extendedae/container/ContainerExInscriber.java
@@ -125,7 +125,12 @@ public class ContainerExInscriber extends UpgradeableMenu<TileExInscriber> imple
     }
 
     public int getStackMode() {
-        return this.getHost().getInvStackSize() == 1 ? 0 : 1;
+        return switch (this.getHost().getInvStackSize()) {
+            case 64 -> 0;
+            case 1 -> 1;
+            case 4 -> 2;
+            default -> throw new IllegalStateException("Unexpected stack size: " + this.getHost().getInvStackSize());
+        };
     }
 
     @Override

--- a/src/main/resources/assets/extendedae/lang/en_us.json
+++ b/src/main/resources/assets/extendedae/lang/en_us.json
@@ -101,6 +101,7 @@
   "gui.extendedae.ex_inscriber.pre": "Previous Inscription Job",
   "gui.extendedae.ex_inscriber.number": "Inscription Job %s",
   "gui.extendedae.ex_inscriber.unstackable": "Stack to 1",
+  "gui.extendedae.ex_inscriber.fourstackable": "Stack to 4",
   "gui.extendedae.ex_inscriber.stackable": "Stack to 64",
   "gui.extendedae.pattern_modifier": "Pattern Modifier (%s)",
   "gui.extendedae.pattern_modifier.multiply": "Multiply Mode",

--- a/src/main/resources/assets/extendedae/lang/ru_ru.json
+++ b/src/main/resources/assets/extendedae/lang/ru_ru.json
@@ -96,6 +96,7 @@
   "gui.extendedae.ex_inscriber.pre": "Предыдущая страница",
   "gui.extendedae.ex_inscriber.number": "Страница %s",
   "gui.extendedae.ex_inscriber.unstackable": "Размер стека - 1",
+  "gui.extendedae.ex_inscriber.fourstackable": "Размер стека - 4",
   "gui.extendedae.ex_inscriber.stackable": "Размер стека - 64",
   "gui.extendedae.ex_io_port": "МЭ Расширенный порт ввода/вывода",
   "gui.extendedae.wireless_connect": "МЭ Беспроводной соединитель",

--- a/src/main/resources/assets/extendedae/lang/zh_cn.json
+++ b/src/main/resources/assets/extendedae/lang/zh_cn.json
@@ -90,6 +90,7 @@
   "gui.extendedae.ex_inscriber.pre": "上一个压印工作",
   "gui.extendedae.ex_inscriber.number": "压印工作 %s",
   "gui.extendedae.ex_inscriber.unstackable": "数量限制 1",
+  "gui.extendedae.ex_inscriber.fourstackable": "数量限制 4",
   "gui.extendedae.ex_inscriber.stackable": "数量限制 64",
   "gui.extendedae.pattern_modifier": "样板修改器（%s）",
   "gui.extendedae.pattern_modifier.multiply": "乘数模式",


### PR DESCRIPTION
该 pr 包含以下特性调整：
- 为扩展压印器添加 4 堆叠模式，并可通过堆叠模式按钮切换
- 调整堆叠模式按钮图标，使其总是使用本体的状态图标 (AE2 19.0.18 版本引入)
- 将默认堆叠数调整为 64，使其与本体行为一致
- 为 4 堆叠模式添加本地化字段

技术性调整：
- 为“默认堆叠数”指定统一的常量 DEFAULT_STACK_SIZE，以便后续维护