### PR TITLE
#251 | Properly flatten & remove duplicates instead of using Set.of() directly | 1.20.1-neoforge

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
+++ b/src/main/java/com/glodblock/github/extendedae/util/FCClientUtil.java
@@ -2,10 +2,13 @@ package com.glodblock.github.extendedae.util;
 
 import com.glodblock.github.extendedae.xmod.ModConstants;
 import com.glodblock.github.glodium.util.GlodClientUtil;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.Direction;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class FCClientUtil {
 
@@ -17,14 +20,14 @@ public class FCClientUtil {
     }
 
     public static String getModName(String inputText) {
-        var trimInput = inputText.trim();
+        String trimInput = inputText.trim();
         if (trimInput.isEmpty() || trimInput.endsWith(",")) {
             return "";
         }
-        var ids = FCUtil.trimSplit(inputText);
-        var set = new ObjectOpenHashSet<>(ids);
+        String[] ids = FCUtil.trimSplit(inputText);
+        Set<String> uniqueInputs = Arrays.stream(ids).collect(Collectors.toSet());
         for (String mod : ModConstants.MOD_NAME) {
-            if (set.contains(mod)) {
+            if (uniqueInputs.contains(mod)) {
                 continue;
             }
             String modid = ids[ids.length - 1];


### PR DESCRIPTION
As mentioned in issue #251. When user puts 2 mod names that start similarly, the game will crash with error `java.lang.IllegalArgumentException: duplicate element: mekanism`.

The problem occurs when Java attempts to convert **String[]** to **Set<String>** directly using `Set.of()`.

It can be fixed by using `Arrays.stream().flatMap()` then convert it to **Set<String>**