### PR TITLE
Change whitelist mechanism

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/common/me/taglist/TagPriorityList.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/me/taglist/TagPriorityList.java
@@ -52,10 +52,12 @@ public class TagPriorityList implements IPartitionList {
             refer = fluid.builtInRegistryHolder();
         }
         if (refer != null) {
-            if (whiteSet.isEmpty()) {
-                return false;
+            boolean pass = true;
+
+            if (!whiteSet.isEmpty()) {
+                pass = refer.tags().anyMatch(whiteSet::contains);
             }
-            boolean pass = refer.tags().anyMatch(whiteSet::contains);
+
             if (pass) {
                 if (!blackSet.isEmpty()) {
                     return refer.tags().noneMatch(blackSet::contains);


### PR DESCRIPTION
This is a change to how the whitelist part of the Tag Storage Bus and Tag Export Bus works. Currently, it seems unintuitive where a blank Whitelist rejects everything, even if you just use the Blacklist. With this change: 

- Blank matches everything
- `*` matches _everything with a tag_

Blacklist works as expected, as do normal tag expressions. My primary purpose with this was to use the Tag Storage Bus to filter items between main "bulk" storage and AE2 disks. Without this change, I don't think I could pass things without a tag. With this, I can blacklist anything I don't want, and the rest pass by default. If I need to whitelist anything with a tag only, I can still do `*` in the whitelist.