### PR TITLE
Replace AETextFields with custom multiline text boxes for tag buses for 1.21.1

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagExportBus.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagExportBus.java
@@ -44,19 +44,28 @@ public class GuiTagExportBus extends UpgradeableScreen<ContainerTagExportBus> im
             if (this.filterInputs2 != null) this.filterInputs2.setValue(o.get(1));
         });
 
-        EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
-    }
-
-    // Factory wspólne dla obu pól
-    private MultilineTextFieldWidget createMultiline(int x, int y, int w, int h, boolean isFirst) {
-        Font font = Minecraft.getInstance().font;
         var placeholder = Component.translatable("gui.extendedae.tag_storage_bus.tooltip");
-        var tf = new MultilineTextFieldWidget(font, x, y, w, h, placeholder);
-        tf.setFilter(ORE_DICTIONARY_FILTER);
-        tf.setMaxLength(1024);
-        tf.setResponder(s -> EAENetworkHandler.INSTANCE
-                .sendToServer(new CEAEGenericPacket("set", s, isFirst)));
-        return tf;
+
+        this.filterInputs = new MultilineTextFieldWidget(
+                Minecraft.getInstance().font, 0, 0, 160, 26, placeholder);
+        this.filterInputs.setFilter(ORE_DICTIONARY_FILTER);
+        this.filterInputs.setMaxLength(1024);
+        this.filterInputs.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, true)));
+
+        this.filterInputs2 = new MultilineTextFieldWidget(
+                Minecraft.getInstance().font, 0, 0, 160, 26, placeholder);
+        this.filterInputs2.setFilter(ORE_DICTIONARY_FILTER);
+        this.filterInputs2.setMaxLength(1024);
+        this.filterInputs2.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, false)));
+
+        widgets.add("filter_input", this.filterInputs);
+        widgets.add("filter_input_2", this.filterInputs2);
+
+        setInitialFocus(this.filterInputs);
+
+        EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
     }
 
     @NotNull
@@ -81,26 +90,5 @@ public class GuiTagExportBus extends UpgradeableScreen<ContainerTagExportBus> im
         super.updateBeforeRender();
         this.redstoneMode.set(menu.getRedStoneMode());
         this.redstoneMode.setVisibility(menu.hasUpgrade(AEItems.REDSTONE_CARD));
-    }
-
-    @Override
-    protected void init() {
-        super.init();
-
-        if (this.filterInputs == null || this.filterInputs2 == null) {
-            var a = style.getWidget("filter_input");
-            var b = style.getWidget("filter_input_2");
-
-            int ax = a.getLeft(), ay = a.getTop(), aw = a.getWidth(), ah = a.getHeight();
-            int bx = b.getLeft(), by = b.getTop(), bw = b.getWidth(), bh = b.getHeight();
-
-            this.filterInputs  = createMultiline(this.getGuiLeft() + ax, this.getGuiTop() + ay, aw, ah, true);
-            this.filterInputs2 = createMultiline(this.getGuiLeft() + bx, this.getGuiTop() + by, bw, bh, false);
-
-            addRenderableWidget(this.filterInputs);
-            addRenderableWidget(this.filterInputs2);
-        }
-
-        setInitialFocus(this.filterInputs);
     }
 }

--- a/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagExportBus.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagExportBus.java
@@ -4,10 +4,10 @@ import appeng.api.config.RedstoneMode;
 import appeng.api.config.Settings;
 import appeng.client.gui.implementations.UpgradeableScreen;
 import appeng.client.gui.style.ScreenStyle;
-import appeng.client.gui.widgets.AETextField;
 import appeng.client.gui.widgets.ServerSettingToggleButton;
 import appeng.client.gui.widgets.SettingToggleButton;
 import appeng.core.definitions.AEItems;
+import com.glodblock.github.extendedae.client.gui.widget.MultilineTextFieldWidget;
 import com.glodblock.github.extendedae.container.ContainerTagExportBus;
 import com.glodblock.github.extendedae.network.EAENetworkHandler;
 import com.glodblock.github.extendedae.network.packet.CEAEGenericPacket;
@@ -19,30 +19,44 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Pattern;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+
 public class GuiTagExportBus extends UpgradeableScreen<ContainerTagExportBus> implements IActionHolder {
 
     private final ActionMap actions = ActionMap.create();
     private final SettingToggleButton<RedstoneMode> redstoneMode;
-    private final AETextField filterInputs;
-    private final AETextField filterInputs2;
-    private static final Pattern ORE_DICTIONARY_FILTER = Pattern.compile("[0-9a-zA-Z* &|^!():/_]*");
+
+    private MultilineTextFieldWidget filterInputs;
+    private MultilineTextFieldWidget filterInputs2;
+
+    private static final Pattern ORE_DICTIONARY_FILTER =
+            Pattern.compile("[0-9a-zA-Z* &|^!():/_\\n]*");
 
     public GuiTagExportBus(ContainerTagExportBus menu, Inventory playerInventory, Component title, ScreenStyle style) {
         super(menu, playerInventory, title, style);
+
         this.redstoneMode = new ServerSettingToggleButton<>(Settings.REDSTONE_CONTROLLED, RedstoneMode.IGNORE);
         addToLeftToolbar(this.redstoneMode);
-        this.filterInputs = widgets.addTextField("filter_input");
-        this.filterInputs.setFilter(str -> ORE_DICTIONARY_FILTER.matcher(str).matches());
-        this.filterInputs.setMaxLength(1024);
-        this.filterInputs.setPlaceholder(Component.translatable("gui.extendedae.tag_storage_bus.tooltip"));
-        this.filterInputs.setResponder(s -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("set", s, true)));
-        this.filterInputs2 = widgets.addTextField("filter_input_2");
-        this.filterInputs2.setFilter(str -> ORE_DICTIONARY_FILTER.matcher(str).matches());
-        this.filterInputs2.setMaxLength(1024);
-        this.filterInputs2.setPlaceholder(Component.translatable("gui.extendedae.tag_storage_bus.tooltip"));
-        this.filterInputs2.setResponder(s -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("set", s, false)));
-        this.actions.put("init", o -> {this.filterInputs.setValue(o.get(0)); this.filterInputs2.setValue(o.get(1));});
+
+        this.actions.put("init", o -> {
+            if (this.filterInputs != null)  this.filterInputs.setValue(o.get(0));
+            if (this.filterInputs2 != null) this.filterInputs2.setValue(o.get(1));
+        });
+
         EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
+    }
+
+    // Factory wspólne dla obu pól
+    private MultilineTextFieldWidget createMultiline(int x, int y, int w, int h, boolean isFirst) {
+        Font font = Minecraft.getInstance().font;
+        var placeholder = Component.translatable("gui.extendedae.tag_storage_bus.tooltip");
+        var tf = new MultilineTextFieldWidget(font, x, y, w, h, placeholder);
+        tf.setFilter(ORE_DICTIONARY_FILTER);
+        tf.setMaxLength(1024);
+        tf.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, isFirst)));
+        return tf;
     }
 
     @NotNull
@@ -53,10 +67,10 @@ public class GuiTagExportBus extends UpgradeableScreen<ContainerTagExportBus> im
 
     @Override
     public boolean mouseClicked(double xCoord, double yCoord, int btn) {
-        if (btn == 1 && this.filterInputs.isMouseOver(xCoord, yCoord)) {
+        if (btn == 1 && this.filterInputs != null && this.filterInputs.isMouseOver(xCoord, yCoord)) {
             this.filterInputs.setValue("");
         }
-        if (btn == 1 && this.filterInputs2.isMouseOver(xCoord, yCoord)) {
+        if (btn == 1 && this.filterInputs2 != null && this.filterInputs2.isMouseOver(xCoord, yCoord)) {
             this.filterInputs2.setValue("");
         }
         return super.mouseClicked(xCoord, yCoord, btn);
@@ -72,7 +86,21 @@ public class GuiTagExportBus extends UpgradeableScreen<ContainerTagExportBus> im
     @Override
     protected void init() {
         super.init();
+
+        if (this.filterInputs == null || this.filterInputs2 == null) {
+            var a = style.getWidget("filter_input");
+            var b = style.getWidget("filter_input_2");
+
+            int ax = a.getLeft(), ay = a.getTop(), aw = a.getWidth(), ah = a.getHeight();
+            int bx = b.getLeft(), by = b.getTop(), bw = b.getWidth(), bh = b.getHeight();
+
+            this.filterInputs  = createMultiline(this.getGuiLeft() + ax, this.getGuiTop() + ay, aw, ah, true);
+            this.filterInputs2 = createMultiline(this.getGuiLeft() + bx, this.getGuiTop() + by, bw, bh, false);
+
+            addRenderableWidget(this.filterInputs);
+            addRenderableWidget(this.filterInputs2);
+        }
+
         setInitialFocus(this.filterInputs);
     }
-
 }

--- a/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagStorageBus.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagStorageBus.java
@@ -16,6 +16,7 @@ import com.glodblock.github.extendedae.client.gui.widget.MultilineTextFieldWidge
 import com.glodblock.github.extendedae.container.ContainerTagStorageBus;
 import com.glodblock.github.extendedae.network.EAENetworkHandler;
 import com.glodblock.github.extendedae.network.packet.CEAEGenericPacket;
+import com.glodblock.github.glodium.network.packet.CGenericPacket;
 import com.glodblock.github.glodium.network.packet.sync.ActionMap;
 import com.glodblock.github.glodium.network.packet.sync.IActionHolder;
 import net.minecraft.client.Minecraft;
@@ -57,18 +58,27 @@ public class GuiTagStorageBus extends UpgradeableScreen<ContainerTagStorageBus> 
             if (this.filterInputs2 != null) this.filterInputs2.setValue(o.get(1));
         });
 
-        EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
-    }
-
-    private MultilineTextFieldWidget createMultiline(int x, int y, int w, int h, boolean first) {
-        Font font = Minecraft.getInstance().font;
         var placeholder = Component.translatable("gui.extendedae.tag_storage_bus.tooltip");
-        var tf = new MultilineTextFieldWidget(font, x, y, w, h, placeholder);
-        tf.setFilter(ORE_DICTIONARY_FILTER);
-        tf.setMaxLength(1024);
-        tf.setResponder(s -> EAENetworkHandler.INSTANCE
-                .sendToServer(new CEAEGenericPacket("set", s, first)));
-        return tf;
+
+        this.filterInputs = new MultilineTextFieldWidget(
+                Minecraft.getInstance().font, 0, 0, 160, 26, placeholder);
+        this.filterInputs.setFilter(ORE_DICTIONARY_FILTER);
+        this.filterInputs.setMaxLength(1024);
+        this.filterInputs.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, true)));
+
+        this.filterInputs2 = new MultilineTextFieldWidget(
+                Minecraft.getInstance().font, 0, 0, 160, 26, placeholder);
+        this.filterInputs2.setFilter(ORE_DICTIONARY_FILTER);
+        this.filterInputs2.setMaxLength(1024);
+        this.filterInputs2.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, false)));
+
+        widgets.add("filter_input", this.filterInputs);
+        widgets.add("filter_input_2", this.filterInputs2);
+
+        setInitialFocus(this.filterInputs);
+        EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
     }
 
     @Override
@@ -104,27 +114,6 @@ public class GuiTagStorageBus extends UpgradeableScreen<ContainerTagStorageBus> 
             guiGraphics.drawString(font, GuiText.Unattached.text(), 0, 0, color.toARGB(), false);
         }
         poseStack.popPose();
-    }
-
-    @Override
-    protected void init() {
-        super.init();
-
-        if (this.filterInputs == null || this.filterInputs2 == null) {
-            var a = style.getWidget("filter_input");
-            var b = style.getWidget("filter_input_2");
-
-            int ax = a.getLeft(), ay = a.getTop(), aw = a.getWidth(), ah = a.getHeight();
-            int bx = b.getLeft(), by = b.getTop(), bw = b.getWidth(), bh = b.getHeight();
-
-            this.filterInputs  = createMultiline(this.getGuiLeft() + ax, this.getGuiTop() + ay, aw, ah, true);
-            this.filterInputs2 = createMultiline(this.getGuiLeft() + bx, this.getGuiTop() + by, bw, bh, false);
-
-            addRenderableWidget(this.filterInputs);
-            addRenderableWidget(this.filterInputs2);
-        }
-
-        setInitialFocus(this.filterInputs);
     }
 
     @NotNull

--- a/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagStorageBus.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/GuiTagStorageBus.java
@@ -8,17 +8,19 @@ import appeng.api.config.YesNo;
 import appeng.client.gui.implementations.UpgradeableScreen;
 import appeng.client.gui.style.PaletteColor;
 import appeng.client.gui.style.ScreenStyle;
-import appeng.client.gui.widgets.AETextField;
 import appeng.client.gui.widgets.ActionButton;
 import appeng.client.gui.widgets.ServerSettingToggleButton;
 import appeng.client.gui.widgets.SettingToggleButton;
 import appeng.core.localization.GuiText;
+import com.glodblock.github.extendedae.client.gui.widget.MultilineTextFieldWidget;
 import com.glodblock.github.extendedae.container.ContainerTagStorageBus;
 import com.glodblock.github.extendedae.network.EAENetworkHandler;
 import com.glodblock.github.extendedae.network.packet.CEAEGenericPacket;
 import com.glodblock.github.glodium.network.packet.sync.ActionMap;
 import com.glodblock.github.glodium.network.packet.sync.IActionHolder;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import org.jetbrains.annotations.NotNull;
@@ -31,12 +33,16 @@ public class GuiTagStorageBus extends UpgradeableScreen<ContainerTagStorageBus> 
     private final SettingToggleButton<AccessRestriction> rwMode;
     private final SettingToggleButton<StorageFilter> storageFilter;
     private final SettingToggleButton<YesNo> filterOnExtract;
-    private final AETextField filterInputs;
-    private final AETextField filterInputs2;
-    private static final Pattern ORE_DICTIONARY_FILTER = Pattern.compile("[0-9a-zA-Z* &|^!():/_]*");
+
+    private MultilineTextFieldWidget filterInputs;
+    private MultilineTextFieldWidget filterInputs2;
+
+    private static final Pattern ORE_DICTIONARY_FILTER =
+            Pattern.compile("[0-9a-zA-Z* &|^!():/_\\n]*");
 
     public GuiTagStorageBus(ContainerTagStorageBus menu, Inventory playerInventory, Component title, ScreenStyle style) {
         super(menu, playerInventory, title, style);
+
         this.widgets.addOpenPriorityButton();
         addToLeftToolbar(new ActionButton(ActionItems.COG, btn -> menu.partition()));
         this.rwMode = new ServerSettingToggleButton<>(Settings.ACCESS, AccessRestriction.READ_WRITE);
@@ -45,29 +51,35 @@ public class GuiTagStorageBus extends UpgradeableScreen<ContainerTagStorageBus> 
         this.addToLeftToolbar(this.storageFilter);
         this.addToLeftToolbar(this.filterOnExtract);
         this.addToLeftToolbar(this.rwMode);
-        this.filterInputs = widgets.addTextField("filter_input");
-        this.filterInputs.setFilter(str -> ORE_DICTIONARY_FILTER.matcher(str).matches());
-        this.filterInputs.setMaxLength(1024);
-        this.filterInputs.setPlaceholder(Component.translatable("gui.extendedae.tag_storage_bus.tooltip"));
-        this.filterInputs.setResponder(s -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("set", s, true)));
-        this.filterInputs2 = widgets.addTextField("filter_input_2");
-        this.filterInputs2.setFilter(str -> ORE_DICTIONARY_FILTER.matcher(str).matches());
-        this.filterInputs2.setMaxLength(1024);
-        this.filterInputs2.setPlaceholder(Component.translatable("gui.extendedae.tag_storage_bus.tooltip"));
-        this.filterInputs2.setResponder(s -> EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("set", s, false)));
-        this.actions.put("init", o -> {this.filterInputs.setValue(o.get(0)); this.filterInputs2.setValue(o.get(1));});
+
+        this.actions.put("init", o -> {
+            if (this.filterInputs != null)  this.filterInputs.setValue(o.get(0));
+            if (this.filterInputs2 != null) this.filterInputs2.setValue(o.get(1));
+        });
+
         EAENetworkHandler.INSTANCE.sendToServer(new CEAEGenericPacket("update"));
     }
 
+    private MultilineTextFieldWidget createMultiline(int x, int y, int w, int h, boolean first) {
+        Font font = Minecraft.getInstance().font;
+        var placeholder = Component.translatable("gui.extendedae.tag_storage_bus.tooltip");
+        var tf = new MultilineTextFieldWidget(font, x, y, w, h, placeholder);
+        tf.setFilter(ORE_DICTIONARY_FILTER);
+        tf.setMaxLength(1024);
+        tf.setResponder(s -> EAENetworkHandler.INSTANCE
+                .sendToServer(new CEAEGenericPacket("set", s, first)));
+        return tf;
+    }
+
     @Override
-    public boolean mouseClicked(double xCoord, double yCoord, int btn) {
-        if (btn == 1 && this.filterInputs.isMouseOver(xCoord, yCoord)) {
+    public boolean mouseClicked(double x, double y, int btn) {
+        if (btn == 1 && this.filterInputs != null && this.filterInputs.isMouseOver(x, y)) {
             this.filterInputs.setValue("");
         }
-        if (btn == 1 && this.filterInputs2.isMouseOver(xCoord, yCoord)) {
+        if (btn == 1 && this.filterInputs2 != null && this.filterInputs2.isMouseOver(x, y)) {
             this.filterInputs2.setValue("");
         }
-        return super.mouseClicked(xCoord, yCoord, btn);
+        return super.mouseClicked(x, y, btn);
     }
 
     @Override
@@ -97,6 +109,21 @@ public class GuiTagStorageBus extends UpgradeableScreen<ContainerTagStorageBus> 
     @Override
     protected void init() {
         super.init();
+
+        if (this.filterInputs == null || this.filterInputs2 == null) {
+            var a = style.getWidget("filter_input");
+            var b = style.getWidget("filter_input_2");
+
+            int ax = a.getLeft(), ay = a.getTop(), aw = a.getWidth(), ah = a.getHeight();
+            int bx = b.getLeft(), by = b.getTop(), bw = b.getWidth(), bh = b.getHeight();
+
+            this.filterInputs  = createMultiline(this.getGuiLeft() + ax, this.getGuiTop() + ay, aw, ah, true);
+            this.filterInputs2 = createMultiline(this.getGuiLeft() + bx, this.getGuiTop() + by, bw, bh, false);
+
+            addRenderableWidget(this.filterInputs);
+            addRenderableWidget(this.filterInputs2);
+        }
+
         setInitialFocus(this.filterInputs);
     }
 

--- a/src/main/java/com/glodblock/github/extendedae/client/gui/widget/MultilineTextFieldWidget.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/widget/MultilineTextFieldWidget.java
@@ -1,0 +1,321 @@
+package com.glodblock.github.extendedae.client.gui.widget;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.MultilineTextField;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import static net.minecraft.client.gui.screens.Screen.hasShiftDown;
+
+@OnlyIn(Dist.CLIENT)
+public class MultilineTextFieldWidget extends AbstractWidget {
+
+    private Consumer<String> responder = s -> {};
+    private Pattern filter = null;
+    private int maxLength = DEFAULT_MAX_LENGTH;
+
+    public static final int DEFAULT_MAX_LENGTH = Integer.MAX_VALUE;
+
+    private final Font font;
+    private final CachedTextField textField;
+    private double scrollAmount;
+    private boolean dragging;
+
+    public MultilineTextFieldWidget(Font font,
+                                    int x, int y,
+                                    int w, int h,
+                                    Component placeholder) {
+        super(x, y, w, h, placeholder);
+        this.font = font;
+        this.textField = new CachedTextField(font, w - 4);
+        this.textField.setCharacterLimit(DEFAULT_MAX_LENGTH);
+        this.textField.setCursorListener(this::clampScroll);
+        this.textField.setValueListener(v -> clampScroll());
+        this.textField.setCursorListener(this::ensureCursorVisible);
+    }
+
+    public void setResponder(Consumer<String> responder) {
+        this.responder = Objects.requireNonNull(responder);
+    }
+
+    public void setFilter(Pattern filter) {
+        this.filter = filter;
+        String cur = getValue();
+        String s = sanitize(cur);
+        if (!s.equals(cur)) {
+            this.textField.setValue(s);
+            onEdited();
+        }
+    }
+
+    public void setMaxLength(int len) {
+        this.maxLength = Math.max(0, len);
+        String cur = getValue();
+        if (cur.length() > maxLength) {
+            this.textField.setValue(cur.substring(0, maxLength));
+            onEdited();
+        }
+    }
+
+    public String getValue() { return textField.value(); }
+    public void setValue(String v) {
+        String s = sanitize(v);
+        textField.setValue(s);
+        onEdited();
+    }
+
+    @Override
+    public boolean keyPressed(int key, int sc, int mod) {
+        if (!isFocused()) return false;
+
+        if (key == GLFW.GLFW_KEY_ENTER || key == GLFW.GLFW_KEY_KP_ENTER) {
+            textField.insertText("\n");
+            clampScroll();
+            ensureCursorVisible();
+            sanitizeAndNotify();
+            return true;
+        }
+
+        boolean handled = textField.keyPressed(key)
+                || Minecraft.getInstance().options.keyInventory.matches(key, sc);
+
+        if (handled) {
+            clampScroll();
+            ensureCursorVisible();
+            sanitizeAndNotify();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean charTyped(char chr, int mods) {
+        if (!isFocused()) return false;
+        if (chr == '\n' || chr == '\r') return true;
+        if (filter != null && !filter.matcher(String.valueOf(chr)).matches()) return true;
+
+        textField.insertText(String.valueOf(chr));
+        clampScroll();
+        ensureCursorVisible();
+        sanitizeAndNotify();
+        return true;
+    }
+
+    @Override
+    public boolean mouseClicked(double mx, double my, int btn) {
+        if (!isActive() || !isValidClickButton(btn) || !clicked(mx, my)) return false;
+
+        Minecraft.getInstance().screen.setFocused(this);
+        setFocused(true);
+
+        if (!hasShiftDown()) {
+            this.textField.setSelecting(false);
+        }
+
+        moveCursorToMouse(mx, my);
+        this.textField.setSelecting(true);
+        dragging = true;
+        return true;
+    }
+
+    @Override
+    public boolean mouseReleased(double mx, double my, int btn) {
+        dragging = false;
+        this.textField.setSelecting(false);
+        return super.mouseReleased(mx, my, btn);
+    }
+
+    @Override
+    public boolean mouseDragged(double mx, double my, int btn, double dx, double dy) {
+        if (dragging && isFocused()) {
+            moveCursorToMouse(mx, my);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput narrationElementOutput) {}
+
+    @Override
+    public boolean mouseScrolled(double mx, double my, double horizontal, double vertical) {
+        if (!isMouseOver(mx, my)) return false;
+        setScrollAmount(scrollAmount - vertical * font.lineHeight);
+        return true;
+    }
+
+
+    public double getMaxScroll() {
+        int textH = textField.lineCount() * font.lineHeight;
+        return Math.max(textH - (height - 4), 0);
+    }
+
+    public void setScrollAmount(double a) {
+        this.scrollAmount = Mth.clamp(a, 0, getMaxScroll());
+    }
+
+    private void clampScroll() {
+        setScrollAmount(this.scrollAmount);
+    }
+
+    private void ensureCursorVisible() {
+        int viewH     = height - 4;
+        int caretLine = textField.lineAtCursor();
+        int caretY    = caretLine * font.lineHeight;
+
+        double top    = scrollAmount;
+        double bottom = scrollAmount + viewH - font.lineHeight;
+
+        if (caretY < top) {
+            setScrollAmount(caretY);
+        } else if (caretY > bottom) {
+            setScrollAmount(caretY - (viewH - font.lineHeight));
+        }
+    }
+
+
+    @Override
+    protected void renderWidget(GuiGraphics g, int mX, int mY, float partial) {
+        RenderSystem.enableDepthTest();
+
+        int bg = 0xFF202020, border = isFocused() ? 0xFFFFFFFF : 0xFF808080;
+        g.fill(getX(), getY(), getX() + width, getY() + height, bg);
+        g.fill(getX(), getY(), getX() + width, getY() + 1, border);
+        g.fill(getX(), getY() + height - 1, getX() + width, getY() + height, border);
+        g.fill(getX(), getY(), getX() + 1, getY() + height, border);
+        g.fill(getX() + width - 1, getY(), getX() + width, getY() + height, border);
+
+        int clipL = getX() + 2, clipT = getY() + 2, clipR = getX() + width - 2, clipB = getY() + height - 2;
+        g.enableScissor(clipL, clipT, clipR, clipB);
+
+        int firstLine = (int) (scrollAmount / font.lineHeight);
+        int y = clipT - (int) scrollAmount + firstLine * font.lineHeight;
+
+        int selectionBegin = textField.hasSelection() ? textField.selection().begin() : -1;
+        int selectionEnd   = textField.hasSelection() ? textField.selection().end()   : -1;
+        int selectionColor = 0x80007FFF;
+
+        for (int idx = firstLine; idx < textField.lineCount() && y <= clipB; idx++) {
+            Line ln = textField.line(idx);
+            String str = textField.value().substring(ln.begin(), ln.end());
+            int xOff = clipL;
+
+            if (textField.hasSelection()) {
+                int lineStartChar = ln.begin();
+                int lineEndChar   = ln.end();
+
+                if (!(selectionEnd <= lineStartChar || selectionBegin >= lineEndChar)) {
+                    int selStartInLine = Math.max(0, selectionBegin - lineStartChar);
+                    int selEndInLine   = Math.min(str.length(), selectionEnd - lineStartChar);
+
+                    if (selStartInLine < selEndInLine) {
+                        String preSel = str.substring(0, selStartInLine);
+                        String selectionText = str.substring(selStartInLine, selEndInLine);
+
+                        int selX = xOff + font.width(preSel);
+                        int selW = font.width(selectionText);
+
+                        g.fill(selX, y, selX + selW, y + font.lineHeight, selectionColor);
+                    }
+                }
+            }
+
+            g.drawString(font, str, xOff, y, 0xFFFFFFFF);
+            y += font.lineHeight;
+        }
+
+        if (isFocused() && blink()) {
+            int curLine = textField.lineAtCursor();
+            Line ln = textField.line(curLine);
+            int cx = clipL + font.width(textField.value().substring(ln.begin(), textField.cursor()));
+            int cy = clipT + curLine * font.lineHeight - (int) scrollAmount;
+            if (cy >= clipT && cy < clipB) g.fill(cx, cy, cx + 1, cy + font.lineHeight, 0xFFFFFFFF);
+        }
+
+        g.disableScissor();
+
+        if (textField.value().isEmpty() && !isFocused()) {
+            g.drawString(font, getMessage(), clipL, clipT, 0xFF808080);
+        }
+    }
+
+    private void sanitizeAndNotify() {
+        String cur = getValue();
+        String s = sanitize(cur);
+        if (!s.equals(cur)) textField.setValue(s);
+        onEdited();
+    }
+
+    private void onEdited() {
+        try { responder.accept(getValue()); } catch (Throwable ignored) {}
+    }
+
+    private String sanitize(String in) {
+        if (in == null) return "";
+        StringBuilder b = new StringBuilder(in.length());
+        for (int i = 0; i < in.length(); i++) {
+            char c = in.charAt(i);
+            if (c == '\r') continue;
+            if (c == '\n') { b.append('\n'); continue; }
+            if (filter == null || filter.matcher(String.valueOf(c)).matches()) b.append(c);
+        }
+        String s = b.toString();
+        if (s.length() > maxLength) s = s.substring(0, maxLength);
+        return s;
+    }
+
+    private void moveCursorToMouse(double mx, double my) {
+        double relX = mx - (getX() + 2);
+        double relY = my - (getY() + 2) + scrollAmount;
+        textField.seekCursorToPoint(relX, relY);
+    }
+    private boolean blink() { return (Util.getMillis() / 500) % 2 == 0; }
+
+    private record Line(int begin, int end) {}
+
+    private static final class CachedTextField extends MultilineTextField {
+        private List<Line> cache = new ArrayList<>();
+        record Selection(int begin, int end) {}
+
+        CachedTextField(Font font, int w) {
+            super(font, w);
+            rebuild();
+        }
+
+        int  lineCount()    { return cache.size(); }
+        Line line(int idx)  { return cache.get(Mth.clamp(idx, 0, cache.size()-1)); }
+        int  lineAtCursor() { return super.getLineAtCursor(); }
+
+        public boolean hasSelection() { return super.hasSelection(); }
+        Selection selection() {
+            var sv = super.getSelected();
+            return new Selection(sv.beginIndex(), sv.endIndex());
+        }
+
+        @Override public void setValue(String v)   { super.setValue(v);   rebuild(); }
+        @Override public void insertText(String t) { super.insertText(t); rebuild(); }
+
+        private void rebuild() {
+            if (cache == null) cache = new ArrayList<>();
+            cache.clear();
+            super.iterateLines().forEach(sv ->
+                    cache.add(new Line(sv.beginIndex(), sv.endIndex()))
+            );
+        }
+    }
+}

--- a/src/main/resources/assets/ae2/screens/tag_export_bus.json
+++ b/src/main/resources/assets/ae2/screens/tag_export_bus.json
@@ -12,12 +12,12 @@
     },
     "whitelist": {
       "text": { "translate": "gui.extendedae.tag_storage_bus.whitelist" },
-      "position": { "right": 8, "top": 16 },
-      "align": "RIGHT"
+      "position": { "left": 8, "top": 54 },
+      "align": "LEFT"
     },
     "blacklist": {
       "text": { "translate": "gui.extendedae.tag_storage_bus.blacklist" },
-      "position": { "right": 8, "top": 54 },
+      "position": { "right": 8, "top": 56 },
       "align": "RIGHT"
     },
 

--- a/src/main/resources/assets/ae2/screens/tag_export_bus.json
+++ b/src/main/resources/assets/ae2/screens/tag_export_bus.json
@@ -7,71 +7,48 @@
   },
   "text": {
     "dialog_title": {
-      "text": {
-        "translate": "gui.extendedae.tag_export_bus"
-      },
-      "position": {
-        "left": 8,
-        "top": 6
-      }
-    },"whitelist": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.whitelist"
-      },
-      "position": {
-        "left": 8,
-        "top": 27
-      }
+      "text": { "translate": "gui.extendedae.tag_export_bus" },
+      "position": { "left": 8, "top": 6 }
+    },
+    "whitelist": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.whitelist" },
+      "position": { "right": 8, "top": 16 },
+      "align": "RIGHT"
     },
     "blacklist": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.blacklist"
-      },
-      "position": {
-        "left": 8,
-        "top": 54
-      }
+      "text": { "translate": "gui.extendedae.tag_storage_bus.blacklist" },
+      "position": { "right": 8, "top": 54 },
+      "align": "RIGHT"
     },
-    "tooltip_01": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.01"
-      },
-      "position": {
-        "left": 8,
-        "top": 81
-      }
+
+    "tooltip_left": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.01" },
+      "position": { "left": 8, "top": 94 },
+      "align": "LEFT"
     },
-    "tooltip_02": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.02"
-      },
-      "position": {
-        "left": 8,
-        "top": 91
-      }
+    "tooltip_right": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.02" },
+      "position": { "right": 8, "top": 94 },
+      "align": "RIGHT"
     },
-    "tooltip_03": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.03"
-      },
-      "position": {
-        "left": 8,
-        "top": 101
-      }
+    "tooltip_bottom": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.03" },
+      "position": { "left": 8, "top": 104 },
+      "align": "LEFT"
     }
   },
   "widgets": {
     "filter_input": {
       "left": 8,
-      "top": 38,
-      "width": 120,
-      "height": 12
+      "top": 26,
+      "width": 160,
+      "height": 26
     },
     "filter_input_2": {
       "left": 8,
-      "top": 65,
-      "width": 120,
-      "height": 12
+      "top": 66,
+      "width": 160,
+      "height": 26
     },
     "openPriority": {
       "left": 152,

--- a/src/main/resources/assets/ae2/screens/tag_storage_bus.json
+++ b/src/main/resources/assets/ae2/screens/tag_storage_bus.json
@@ -7,72 +7,49 @@
   },
   "text": {
     "dialog_title": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus"
-      },
-      "position": {
-        "left": 8,
-        "top": 6
-      }
+      "text": { "translate": "gui.extendedae.tag_storage_bus" },
+      "position": { "left": 8, "top": 4 }
     },
     "whitelist": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.whitelist"
-      },
-      "position": {
-        "left": 8,
-        "top": 27
-      }
+      "text": { "translate": "gui.extendedae.tag_storage_bus.whitelist" },
+      "position": { "left": 8, "top": 54 },
+      "align": "LEFT"
     },
     "blacklist": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.blacklist"
-      },
-      "position": {
-        "left": 8,
-        "top": 54
-      }
+      "text": { "translate": "gui.extendedae.tag_storage_bus.blacklist" },
+      "position": { "right": 8, "top": 56 },
+      "align": "RIGHT"
     },
-    "tooltip_01": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.01"
-      },
-      "position": {
-        "left": 8,
-        "top": 81
-      }
+
+    "tooltip_left": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.01" },
+      "position": { "left": 8, "top": 94 },
+      "align": "LEFT"
     },
-    "tooltip_02": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.02"
-      },
-      "position": {
-        "left": 8,
-        "top": 91
-      }
+    "tooltip_right": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.02" },
+      "position": { "right": 8, "top": 94 },
+      "align": "RIGHT"
     },
-    "tooltip_03": {
-      "text": {
-        "translate": "gui.extendedae.tag_storage_bus.desc.03"
-      },
-      "position": {
-        "left": 8,
-        "top": 101
-      }
+
+    "tooltip_bottom": {
+      "text": { "translate": "gui.extendedae.tag_storage_bus.desc.03" },
+      "position": { "left": 8, "top": 104 },
+      "align": "LEFT"
     }
   },
   "widgets": {
     "filter_input": {
       "left": 8,
-      "top": 38,
-      "width": 120,
-      "height": 12
+      "top": 26,
+      "width": 160,
+      "height": 26
     },
     "filter_input_2": {
       "left": 8,
-      "top": 65,
-      "width": 120,
-      "height": 12
+      "top": 66,
+      "width": 160,
+      "height": 26
     },
     "openPriority": {
       "left": 152,


### PR DESCRIPTION
This PR replaces the default AETextField inputs with a custom MultilineTextFieldWidget.
Thanks to this, writing longer or more complex filters is much easier and more user-friendly.

Changes:

Added MultilineTextFieldWidget supporting:
- multiple lines (Enter inserts \n),
- regex filtering + max length,
- scrolling and selection,
- responder callback after every edit (keeps server sync working).

Updated Tag Export Bus and Tag Storage Bus GUIs to use the new widget.
Layouts adjusted so the larger text boxes fit comfortably without overlapping the inventory.

https://github.com/user-attachments/assets/6e4f85b1-f03c-46a3-a4c5-2e13640e0695

