### PR TITLE
Closes #299: Show custom names of Assembler Matrix Pattern Blocks on Pattern Access Terminal

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/common/tileentities/matrix/TileAssemblerMatrixPattern.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/tileentities/matrix/TileAssemblerMatrixPattern.java
@@ -152,7 +152,8 @@ public class TileAssemblerMatrixPattern extends TileAssemblerMatrixFunction impl
     @Override
     public PatternContainerGroup getTerminalGroup() {
         var icon = AEItemKey.of(EAESingletons.ASSEMBLER_MATRIX_PATTERN);
-        return new PatternContainerGroup(icon, icon.getDisplayName(), List.of(Component.translatable("gui.extendedae.assembler_matrix.pattern")));
+        var name = this.hasCustomName() ? this.getCustomName() : icon.getDisplayName();
+        return new PatternContainerGroup(icon, name, List.of(Component.translatable("gui.extendedae.assembler_matrix.pattern")));
     }
 
     public record Filter(Supplier<Level> world) implements IAEItemFilter {


### PR DESCRIPTION
This PRs allows custom names made to the Assembler Matrix Pattern Blocks to show up on the Pattern Access Terminals. The renaming work the same as Pattern Providers, using an anvil or the quartz knife.