### PR TITLE
add configurable conversion loss when storing FE into a flux cell

### DIFF
--- a/src/main/java/com/glodblock/github/appflux/common/me/cell/FluxCellInventory.java
+++ b/src/main/java/com/glodblock/github/appflux/common/me/cell/FluxCellInventory.java
@@ -14,6 +14,7 @@ import com.glodblock.github.appflux.common.AFSingletons;
 import com.glodblock.github.appflux.common.me.key.FluxKey;
 import com.glodblock.github.appflux.common.me.key.type.EnergyType;
 import com.glodblock.github.appflux.common.me.key.type.FluxKeyType;
+import com.glodblock.github.appflux.config.AFConfig;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -88,15 +89,16 @@ public abstract class FluxCellInventory implements StorageCell {
         if (!(what instanceof FluxKey)) {
             return 0;
         }
-
-        var inserted = Math.min(getMaxEnergy() - this.storedEnergy, amount);
+        var convertedAmount = (long)(amount * AFConfig.getConversionRate());
+        var inserted = Math.min(getMaxEnergy() - this.storedEnergy, convertedAmount);
 
         if (mode == Actionable.MODULATE) {
             this.storedEnergy += inserted;
             saveChanges();
         }
 
-        return this.hasVoidUpgrade ? amount : inserted;
+        // Need to return the amount before conversion loss so it will be deducted from the source correctly.
+        return this.hasVoidUpgrade ? amount : (long)(inserted / AFConfig.getConversionRate());
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/appflux/config/AFConfig.java
+++ b/src/main/java/com/glodblock/github/appflux/config/AFConfig.java
@@ -14,6 +14,9 @@ public class AFConfig {
     private static final ModConfigSpec.IntValue FLUX_PER_BYTE = BUILDER
             .comment("FE can be stored per byte.")
             .defineInRange("flux_cell.amount", 1024 * 1024, 1, Integer.MAX_VALUE);
+    private static final ModConfigSpec.DoubleValue CONVERSION_LOSS_RATE = BUILDER
+            .comment("Percentage of FE lost when stored into Flux Cells.")
+            .defineInRange("flux_cell.conversion_loss_percentage", 0.025, 0, 0.999999);
     private static final ModConfigSpec.LongValue FLUX_ACCESSOR_IO = BUILDER
             .comment("The I/O limit of Flux Accessor. 0 means no limitation.")
             .defineInRange("flux_accessor.io_limit", 0L, 0L, Integer.MAX_VALUE);
@@ -34,6 +37,10 @@ public class AFConfig {
         return fluxPerByte;
     }
 
+    public static double getConversionRate() {
+        return conversionRate;
+    }
+
     public static long getFluxAccessorIO() {
         return fluxAccessorIO <= 0 ? Long.MAX_VALUE : fluxAccessorIO;
     }
@@ -51,6 +58,7 @@ public class AFConfig {
     }
 
     private static int fluxPerByte;
+    private static double conversionRate;
     private static long fluxAccessorIO;
     private static boolean selfCharge;
     private static boolean allowImportBus;
@@ -59,6 +67,7 @@ public class AFConfig {
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event) {
         fluxPerByte = FLUX_PER_BYTE.get();
+        conversionRate = 1.0 - CONVERSION_LOSS_RATE.get();
         fluxAccessorIO = FLUX_ACCESSOR_IO.get();
         selfCharge = NETWORK_CHARGE.get();
         allowImportBus = ENABLE_IMPORT.get();

--- a/src/main/resources/assets/appflux/ae2guide/appflux/flux_accessor.md
+++ b/src/main/resources/assets/appflux/ae2guide/appflux/flux_accessor.md
@@ -25,6 +25,8 @@ changed in Appflux config.
 They have fast and normal mode. In fast mode, it outputs energy in every tick, which may cause lag if it is heavily used.
 In normal mode, it outputs energy depends on target's stored energy, which won't cause lag issues.
 
+When the Flux Accessor is storing energy to FE Storage Cells, a percentage of the incoming energy is lost. The default is 2.5%,
+matching the default loss when transfering energy via an Energy P2P Tunnel. This percentage is configurable.
+
 * Notice: The "energy" mentioned here is FE stored in your [FE Storage Cells](./flux_cells.md), not the energy in
 [Energy Cells](ae2:items-blocks-machines/energy_cells.md).
-


### PR DESCRIPTION
Implements https://github.com/GlodBlock/ExtendedAE/issues/541

Adds a percentage loss when importing FE into FE Storage Cells.

I set the default at 2.5% to match AE2's Energy P2P losses, but it may need to be set to 0% until a major version bump because it can break existing setups which are currently endlessly looping power in and out every tick. An easy example of this is Mekanism universal cables. It will quickly drain overall power with them connected unless you set the cable to push or pull explicitly on the flux accessor.

I'm sure there are issues with this on edge cases and maybe from rounding issues, but I took a stab at this to play around with. I will try to setup some better testing saves with this when I get a chance.