### PR TITLE
Fix(GUI): Align max export amount with part's operational capacity

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/client/gui/subgui/SetAmount.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/subgui/SetAmount.java
@@ -73,6 +73,6 @@ public class SetAmount<C extends AEBaseMenu, P extends AEBaseScreen<C>> extends 
     }
 
     private long getMaxAmount() {
-        return 64L * (long) currentStack.what().getAmountPerUnit();
+        return 64L * (long) currentStack.what().getAmountPerOperation();
     }
 }


### PR DESCRIPTION
fix https://github.com/GlodBlock/ExtendedAE/issues/407
fix https://github.com/GlodBlock/ExtendedAE/issues/395