### PR TITLE
Fix(GUI): Align max export amount with part's operational capacity

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/client/gui/subgui/SetAmount.java
+++ b/src/main/java/com/glodblock/github/extendedae/client/gui/subgui/SetAmount.java
@@ -70,6 +70,6 @@ public class SetAmount<C extends AEBaseMenu, P extends AEBaseScreen<C>> extends 
     }
 
     private long getMaxAmount() {
-        return 64L * (long) currentStack.what().getAmountPerUnit();
+        return 64L * (long) currentStack.what().getAmountPerOperation();
     }
 }


### PR DESCRIPTION
使用emi拖拽设置 会导致超过设置上限 我无法解决