### PR TITLE
Add Item IDs to the TagExpParser

### DIFF
--- a/src/main/java/com/glodblock/github/extendedae/common/me/taglist/TagExpParser.java
+++ b/src/main/java/com/glodblock/github/extendedae/common/me/taglist/TagExpParser.java
@@ -85,16 +85,24 @@ public final class TagExpParser {
         Holder<?> holder = null;
         if (key instanceof Item item) {
             holder = item.builtInRegistryHolder();
-        } else if (key instanceof Fluid fluid) {
-            holder = fluid.builtInRegistryHolder();
-        }
-
-        if (holder != null) {
-            // Convert TagKey objects to their string representation for matching.
-            Set<String> tagStrings = holder.tags()
+            if (holder != null) {
+                Set<String> tagStrings = holder.tags()
                     .map(tagKey -> tagKey.location().toString())
                     .collect(Collectors.toSet());
-            return predicate.test(tagStrings);
+                // Add the item ID (registry name)
+                holder.unwrapKey().ifPresent(resourceKey -> tagStrings.add(resourceKey.location().toString()));
+                return predicate.test(tagStrings);
+            }
+        } else if (key instanceof Fluid fluid) {
+            holder = fluid.builtInRegistryHolder();
+            if (holder != null) {
+                Set<String> tagStrings = holder.tags()
+                    .map(tagKey -> tagKey.location().toString())
+                    .collect(Collectors.toSet());
+                // Add the fluid ID (registry name)
+                holder.unwrapKey().ifPresent(resourceKey -> tagStrings.add(resourceKey.location().toString()));
+                return predicate.test(tagStrings);
+            }
         }
 
         return false; // Cannot evaluate if not an Item or Fluid with tags.


### PR DESCRIPTION
This should effectively treat item tags and ids in the same expression, the only problem I've been able to find with this so far is it will essentially filter the _entire_ name so it no longer would require the name in the beginning. For example, 'c:storage_block*' would also allow any tags such as 'c:storage_blocks/*' this could create problems with items with similar IDs. I've tested this in the GametestWorld and it seems to filter IDs now as well. So, as I've had a problem with before, items can be wildcarded, so 'allthecompressed:*' is now a valid expression allowing all blocks from the mod to export, but 'allthecompressed:raw*' will now allow all blocks from the mod to be exported. Because of this, the list can be very generalized so '*raw*' will move anything with any ID or tag containing the word raw.