### PR TITLE
Fix server crash (NPE) when wireless connector ticks before AE2 grid nodes exist

### DIFF
--- a/src/main/java/com/glodblock/github/epp/common/me/WirelessConnect.java
+++ b/src/main/java/com/glodblock/github/epp/common/me/WirelessConnect.java
@@ -49,7 +49,11 @@ public class WirelessConnect implements IActionHost {
         }
     }
 
-    public void updateStatus() {
+    /**
+     * @return false if the update could not complete because an AE2 grid node
+     *         is not available yet and should be retried next tick.
+     */
+    public boolean updateStatus() {
         final long f = this.host.getFrequency();
         if (this.thisSide != f && this.thisSide != -f) {
             if (f != 0) {
@@ -75,6 +79,7 @@ public class WirelessConnect implements IActionHost {
 
         this.shutdown = false;
         this.dis = 0;
+        boolean completed = true;
 
         if (myOtherSide instanceof WirelessConnect sideB) {
             var sideA = this;
@@ -82,28 +87,35 @@ public class WirelessConnect implements IActionHost {
             if (sideA.isActive() && sideB.isActive()
                     && this.dis <= EPPConfig.INSTANCE.wirelessConnectorMaxRange
                     && (sideA.host.getWorld() == sideB.host.getWorld())) {
-                if (this.connection != null && this.connection.getConnection() != null) {
-                    final IGridNode a = this.connection.getConnection().a();
-                    final IGridNode b = this.connection.getConnection().b();
-                    final IGridNode sa = sideA.getNode();
-                    final IGridNode sb = sideB.getNode();
-                    if ((a == sa || b == sa) && (a == sb || b == sb)) {
-                        return;
+                final IGridNode nodeA = sideA.getNode();
+                final IGridNode nodeB = sideB.getNode();
+                if (nodeA == null || nodeB == null) {
+                    // AE2 creates grid nodes lazily, so they may not exist yet during startup
+                    this.shutdown = true;
+                    completed = false;
+                } else {
+                    if (this.connection != null && this.connection.getConnection() != null) {
+                        final IGridNode a = this.connection.getConnection().a();
+                        final IGridNode b = this.connection.getConnection().b();
+                        if ((a == nodeA || b == nodeA) && (a == nodeB || b == nodeB)) {
+                            return true;
+                        }
                     }
-                }
 
-                try {
-                    if (sideA.connection != null && sideA.connection.getConnection() != null) {
-                        sideA.connection.getConnection().destroy();
-                        sideA.connection = new ConnectionWrapper(null);
+                    try {
+                        if (sideA.connection != null && sideA.connection.getConnection() != null) {
+                            sideA.connection.getConnection().destroy();
+                            sideA.connection = new ConnectionWrapper(null);
+                        }
+                        if (sideB.connection != null && sideB.connection.getConnection() != null) {
+                            sideB.connection.getConnection().destroy();
+                            sideB.connection = new ConnectionWrapper(null);
+                        }
+                        sideA.connection = sideB.connection = new ConnectionWrapper(GridHelper.createGridConnection(nodeA, nodeB));
+                    } catch (FailedConnectionException e) {
+                        this.shutdown = true;
+                        EPP.LOGGER.debug("Failed to connect wireless connectors", e);
                     }
-                    if (sideB.connection != null && sideB.connection.getConnection() != null) {
-                        sideB.connection.getConnection().destroy();
-                        sideB.connection = new ConnectionWrapper(null);
-                    }
-                    sideA.connection = sideB.connection = new ConnectionWrapper(GridHelper.createGridConnection(sideA.getNode(), sideB.getNode()));
-                } catch (FailedConnectionException e) {
-                    EPP.LOGGER.debug(e.getMessage());
                 }
             } else {
                 this.shutdown = true;
@@ -117,6 +129,7 @@ public class WirelessConnect implements IActionHost {
             this.connection.setConnection(null);
             this.connection = new ConnectionWrapper(null);
         }
+        return completed;
     }
 
     public double getDistance() {
@@ -124,7 +137,7 @@ public class WirelessConnect implements IActionHost {
     }
 
     public boolean isConnected() {
-        return !this.shutdown;
+        return !this.shutdown && this.connection != null && this.connection.getConnection() != null;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/glodblock/github/epp/common/tiles/TileWirelessConnector.java
+++ b/src/main/java/com/glodblock/github/epp/common/tiles/TileWirelessConnector.java
@@ -37,10 +37,12 @@ public class TileWirelessConnector extends AENetworkBlockEntity implements Serve
     @Override
     public void serverTick() {
         if (this.updateStatus) {
-            this.updateStatus = false;
-            this.connect.updateStatus();
+            // retry every tick until the AE2 grid nodes of both sides exist
+            if (this.connect.updateStatus()) {
+                this.updateStatus = false;
+                this.markForUpdate();
+            }
             this.updatePowerUsage();
-            this.markForUpdate();
         }
     }
 


### PR DESCRIPTION
## Problem

`WirelessConnect.updateStatus()` passes `getNode()` results directly into
`GridHelper.createGridConnection()` without a null check. AE2 creates grid
nodes lazily, so when a wireless connector pair ticks during world/chunk
load, one side's node may not exist yet. AE2 then throws an uncaught
NullPointerException and the server crashes with "Ticking block entity":

```
java.lang.NullPointerException: Ticking block entity
	at appeng.api.networking.GridHelper.createGridConnection(GridHelper.java:188)
	at com.glodblock.github.epp.common.me.WirelessConnect.updateStatus(WirelessConnect.java:104)
	at com.glodblock.github.epp.common.tiles.TileWirelessConnector.serverTick(TileWirelessConnector.java:41)
```

Once a world is in this state it crashes on every load, since the connector
ticks before AE2 finishes initializing.

## Fix

- Null-check both grid nodes before calling `createGridConnection`; a
  missing node is treated as temporarily disconnected instead of crashing.
- `updateStatus()` now returns whether it completed, and
  `TileWirelessConnector.serverTick()` keeps retrying each tick until both
  nodes exist — so affected connectors self-heal once the grid is up,
  and previously broken worlds recover without removing the block.
- `isConnected()` now also requires an actual established connection, so
  the block state / power usage can't report a connection that failed to
  initialize (previously it only checked the `shutdown` flag).
- `FailedConnectionException` now marks the connector as shut down.

Tested on 1.19.2 fabric: a world that crashed on load with the above trace
now loads, and the connector pair reconnects automatically.
